### PR TITLE
Some fixes for the first install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ $ vagrant ssh production
 ## Installation
 
 Install dependancies : 
+ 
+### the first time 
+```bash
+$ sudo composer self-update
+$ composer update -n # due to CVE-2019-18889, CVE-2019-18888, CVE-2019-18887, CVE-2019-18886, CVE-2019-11325
+```
 
 ```bash
 $ composer install -n 


### PR DESCRIPTION
Example of errors :  
- ocramius/package-versions 1.4.0 requires composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
- Script security-checker security:check returned with error code 1 : 6 packages have known vulnerabilities.